### PR TITLE
修复了比价脚本会在非京东/淘宝页面执行的bug

### DIFF
--- a/jd-histroy-price.user.js
+++ b/jd-histroy-price.user.js
@@ -4,8 +4,8 @@
 // @namespace   https://github.com/gam2046/userscript
 // @description Shown histroy price of jd.com / taobao.com / taobao.com & No ADs & Coupon
 // @description:zh-CN [无广告] [慎重:会转链]] 显示京东/天猫商城/淘宝集市 历史价格，支持淘宝、天猫隐藏优惠券领取。
-// @include     /http(?:s|)://(?:item\.(?:jd|yiyaojd)\.(?:[^./]+)/\d+\.html|.+)/
-// @include     /http(?:s|)://(?:detail|item)\.(?:taobao|tmall)\.(?:[^./]+)/item.htm/
+// @include     /http(?:s|):\/\/item\.(?:jd|yiyaojd)\.(?:[^.\/]+)\/(?:\d+\.html|.+)/
+// @include     /http(?:s|):\/\/(?:detail|item)\.(?:taobao|tmall)\.(?:[^.\/]+)\/item.htm/
 // @include     /amazon\.com/
 // @updateURL   https://github.com/gam2046/userscript/raw/master/jd-histroy-price.user.js
 // @require     https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.1/Chart.bundle.min.js


### PR DESCRIPTION
主要是第一个@include的正则：
`/http(?:s|)://(?:item\.(?:jd|yiyaojd)\.(?:[^./]+)/\d+\.html|.+)/`

第二个`(?:)`直接到尾部，然后在非京东网站，`|`右边的`.+`就会生效